### PR TITLE
Fixed paragraph styles being reset

### DIFF
--- a/Clean up SFUI Type.sketchplugin/Contents/Sketch/script.cocoascript
+++ b/Clean up SFUI Type.sketchplugin/Contents/Sketch/script.cocoascript
@@ -145,7 +145,7 @@ var onRun = function(context, scale) {
         textStorage.addAttribute_value_range(NSKernAttributeName, characterSpacing, range);
 
         var newAttributes = textStorage.fontAttributesInRange(range);
-        textLayer.setAttributes_forRange(newAttributes, range);
+        textLayer.addAttributes_forRange(newAttributes, range);
       }
 
       spacing = undefined;


### PR DESCRIPTION
Right now the plugin replaces the original attributes with only the character attributes excluding links, paragraph styles and attachments. This change only sets the changed attributes and leaves the existing attributes.

**[NSAttributedString fontAttributesInRange:](https://developer.apple.com/documentation/foundation/nsattributedstring/1528371-fontattributesinrange)**
The dictionary attributes are all those listed in Character Attributes, except 
`NSLinkAttributeName`, `NSParagraphStyleAttributeName`, and `NSAttachmentAttributeName`

**Reproduce:**
- Create a text layer in Sketch with multiple lines of text that very in length
- Set alignment to centered
- Run plugin `Clean Up SF Type`
- The text should now be aligned to the left